### PR TITLE
Correct baseURL to have a slash at the end

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title = "Network Service Mesh"
-baseURL = "https://www.networkservicemesh.io"
+baseURL = "https://www.networkservicemesh.io/"
 languageCode = "en-us"
 theme = "airspace-hugo"
 


### PR DESCRIPTION
Signed-off-by: Kyle Mestery <mestery@mestery.com>